### PR TITLE
Integrate per-chat PGP key dialog

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -51,6 +51,7 @@ import org.telegram.tgnet.TLObject;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.tgnet.tl.TL_stories;
 import org.telegram.ui.ActionBar.Theme;
+import org.telegram.messenger.PgpHelper;
 import org.telegram.ui.Business.QuickRepliesController;
 import org.telegram.ui.Cells.ChatMessageCell;
 import org.telegram.ui.ChatActivity;
@@ -3481,6 +3482,8 @@ public class MessageObject {
         if (TextUtils.isEmpty(text)) {
             return;
         }
+        String decrypted = PgpHelper.decrypt(text.toString());
+        text = decrypted;
         TLRPC.User fromUser = null;
         if (isFromUser()) {
             fromUser = MessagesController.getInstance(currentAccount).getUser(messageOwner.from_id.user_id);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/PgpHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/PgpHelper.java
@@ -11,6 +11,8 @@ import org.bouncycastle.openpgp.PGPEncryptedDataGenerator;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
 import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
 import org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder;
@@ -25,31 +27,42 @@ import java.security.Security;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.Random;
+import java.security.SecureRandom;
 
 public class PgpHelper {
     private static final String PREFS = "pgp_keys";
-    private static final String PUBLIC_KEY = "public_key";
+    private static final String PUBLIC_KEY_PREFIX = "public_key_";
     private static final String PRIVATE_KEY = "private_key";
 
     private static SharedPreferences prefs() {
         return ApplicationLoader.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
     }
 
-    public static void saveKeys(String publicKey, String privateKey) {
-        prefs().edit().putString(PUBLIC_KEY, publicKey).putString(PRIVATE_KEY, privateKey).apply();
+    public static void saveKeys(long dialogId, String publicKey, String privateKey) {
+        SharedPreferences.Editor e = prefs().edit();
+        if (publicKey != null) {
+            e.putString(PUBLIC_KEY_PREFIX + dialogId, publicKey);
+        }
+        if (privateKey != null) {
+            e.putString(PRIVATE_KEY, privateKey);
+        }
+        e.apply();
     }
 
-    public static String getPublicKey() {
-        return prefs().getString(PUBLIC_KEY, "");
+    public static String getPublicKey(long dialogId) {
+        return prefs().getString(PUBLIC_KEY_PREFIX + dialogId, "");
     }
 
     public static String getPrivateKey() {
         return prefs().getString(PRIVATE_KEY, "");
     }
 
-    public static boolean hasKeys() {
-        return !TextUtils.isEmpty(getPublicKey()) && !TextUtils.isEmpty(getPrivateKey());
+    public static boolean hasKeys(long dialogId) {
+        return !TextUtils.isEmpty(getPublicKey(dialogId)) && !TextUtils.isEmpty(getPrivateKey());
+    }
+
+    public static boolean hasPrivateKey() {
+        return !TextUtils.isEmpty(getPrivateKey());
     }
 
     private static PGPPublicKey readPublicKey(InputStream in) throws Exception {
@@ -68,10 +81,10 @@ public class PgpHelper {
         return null;
     }
 
-    public static String encrypt(String message) {
+    public static String encrypt(long dialogId, String message) {
         try {
             Security.addProvider(new BouncyCastleProvider());
-            PGPPublicKey key = readPublicKey(new ByteArrayInputStream(getPublicKey().getBytes(StandardCharsets.UTF_8)));
+            PGPPublicKey key = readPublicKey(new ByteArrayInputStream(getPublicKey(dialogId).getBytes(StandardCharsets.UTF_8)));
             if (key == null) {
                 return message;
             }
@@ -80,7 +93,7 @@ public class PgpHelper {
             PGPEncryptedDataGenerator encGen = new PGPEncryptedDataGenerator(
                     new JcePGPDataEncryptorBuilder(PGPEncryptedData.AES_256)
                             .setWithIntegrityPacket(true)
-                            .setSecureRandom(new Random())
+                            .setSecureRandom(new SecureRandom())
                             .setProvider("BC"));
             encGen.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(key).setProvider("BC"));
             OutputStream cOut = encGen.open(armoredOut, new byte[4096]);
@@ -88,6 +101,62 @@ public class PgpHelper {
             cOut.close();
             armoredOut.close();
             return out.toString("UTF-8");
+        } catch (Throwable e) {
+            FileLog.e(e);
+        }
+        return message;
+    }
+
+    private static PGPSecretKey readSecretKey(InputStream in) throws Exception {
+        PGPSecretKeyRingCollection pgpSec = new PGPSecretKeyRingCollection(PGPUtil.getDecoderStream(in), new JcaKeyFingerprintCalculator());
+        Iterator<PGPSecretKey> keyRingIter = pgpSec.getKeyRings().next().getSecretKeys();
+        while (keyRingIter.hasNext()) {
+            PGPSecretKey key = keyRingIter.next();
+            if (key.isSigningKey()) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    public static String decrypt(String message) {
+        if (!hasPrivateKey() || TextUtils.isEmpty(message)) {
+            return message;
+        }
+        try {
+            Security.addProvider(new BouncyCastleProvider());
+            InputStream in = PGPUtil.getDecoderStream(new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8)));
+            org.bouncycastle.openpgp.PGPObjectFactory pgpFactory = new org.bouncycastle.openpgp.PGPObjectFactory(in, new JcaKeyFingerprintCalculator());
+            Object o = pgpFactory.nextObject();
+            if (o instanceof org.bouncycastle.openpgp.PGPEncryptedDataList) {
+                org.bouncycastle.openpgp.PGPEncryptedDataList encList = (org.bouncycastle.openpgp.PGPEncryptedDataList) o;
+                Iterator<?> it = encList.getEncryptedDataObjects();
+                PGPSecretKey secretKey = null;
+                org.bouncycastle.openpgp.PGPPublicKeyEncryptedData pbe = null;
+                while (it.hasNext()) {
+                    pbe = (org.bouncycastle.openpgp.PGPPublicKeyEncryptedData) it.next();
+                    secretKey = readSecretKey(new ByteArrayInputStream(getPrivateKey().getBytes(StandardCharsets.UTF_8)));
+                    if (secretKey != null && secretKey.getKeyID() == pbe.getKeyID()) {
+                        break;
+                    }
+                }
+                if (secretKey != null) {
+                    org.bouncycastle.openpgp.PGPPrivateKey privKey = secretKey.extractPrivateKey(new org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder().setProvider("BC").build(new char[0]));
+                    InputStream clear = pbe.getDataStream(new org.bouncycastle.openpgp.operator.jcajce.JcePublicKeyDataDecryptorFactoryBuilder().setProvider("BC").build(privKey));
+                    org.bouncycastle.openpgp.PGPObjectFactory pgpFact = new org.bouncycastle.openpgp.PGPObjectFactory(clear, new JcaKeyFingerprintCalculator());
+                    Object messageObj = pgpFact.nextObject();
+                    if (messageObj instanceof org.bouncycastle.openpgp.PGPLiteralData) {
+                        org.bouncycastle.openpgp.PGPLiteralData ld = (org.bouncycastle.openpgp.PGPLiteralData) messageObj;
+                        ByteArrayOutputStream out = new ByteArrayOutputStream();
+                        InputStream unc = ld.getInputStream();
+                        int ch;
+                        while ((ch = unc.read()) >= 0) {
+                            out.write(ch);
+                        }
+                        return out.toString("UTF-8");
+                    }
+                }
+            }
         } catch (Throwable e) {
             FileLog.e(e);
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -4379,16 +4379,6 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
                     });
                     sendPopupLayout.addView(sendWithoutSoundButton, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48));
 
-                    ActionBarMenuSubItem pgpButton = new ActionBarMenuSubItem(getContext(), true, true, resourcesProvider);
-                    pgpButton.setTextAndIcon(LocaleController.getString(R.string.PgpSettings), R.drawable.msg_mini_lock2);
-                    pgpButton.setMinimumWidth(dp(196));
-                    pgpButton.setOnClickListener(v -> {
-                        if (sendPopupWindow != null && sendPopupWindow.isShowing()) {
-                            sendPopupWindow.dismiss();
-                        }
-                        showPgpDialog();
-                    });
-                    sendPopupLayout.addView(pgpButton, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48));
                 }
                 sendPopupLayout.setupRadialSelectors(getThemedColor(Theme.key_dialogButtonSelector));
 
@@ -4618,7 +4608,6 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
                     AndroidUtilities.runOnUIThread(dismissSendPreview, 500);
                 }
             });
-            options.add(R.drawable.msg_mini_lock2, getString(R.string.PgpSettings), this::showPgpDialog);
         }
         options.setupSelectors();
         if (sendWhenOnlineButton != null) {
@@ -6738,33 +6727,6 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
         return false;
     }
 
-    private void showPgpDialog() {
-        if (parentActivity == null) {
-            return;
-        }
-        AlertDialog.Builder builder = new AlertDialog.Builder(parentActivity, resourcesProvider);
-        builder.setTitle(LocaleController.getString("PgpSettings", R.string.PgpSettings));
-        LinearLayout layout = new LinearLayout(parentActivity);
-        layout.setOrientation(LinearLayout.VERTICAL);
-        EditText publicKey = new EditText(parentActivity);
-        publicKey.setHint(LocaleController.getString("PgpPublicKey", R.string.PgpPublicKey));
-        publicKey.setText(PgpHelper.getPublicKey());
-        EditText privateKey = new EditText(parentActivity);
-        privateKey.setHint(LocaleController.getString("PgpPrivateKey", R.string.PgpPrivateKey));
-        privateKey.setText(PgpHelper.getPrivateKey());
-        layout.addView(publicKey, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 16f, 8f, 16f, 8f));
-        layout.addView(privateKey, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 16f, 8f, 16f, 8f));
-        builder.setView(layout);
-        builder.setPositiveButton(LocaleController.getString("Save", R.string.Save), (dialog, which) -> {
-            PgpHelper.saveKeys(publicKey.getText().toString(), privateKey.getText().toString());
-        });
-        builder.setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null);
-        if (parentFragment != null) {
-            parentFragment.showDialog(builder.create());
-        } else {
-            builder.show();
-        }
-    }
 
     public static boolean checkPremiumAnimatedEmoji(int currentAccount, long dialogId, BaseFragment parentFragment, FrameLayout container, CharSequence message) {
         if (message == null || parentFragment == null) {
@@ -7118,8 +7080,8 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
                     replyToTopMsg = replyingTopMessage;
                 }
                 String sendText = message[0].toString();
-                if (PgpHelper.hasKeys()) {
-                    sendText = PgpHelper.encrypt(sendText);
+                if (PgpHelper.hasKeys(dialog_id)) {
+                    sendText = PgpHelper.encrypt(dialog_id, sendText);
                 }
                 SendMessagesHelper.SendMessageParams params = SendMessagesHelper.SendMessageParams.of(sendText, dialog_id, replyingMessageObject, replyToTopMsg, messageWebPage, messageWebPageSearch, entities, null, null, notify, scheduleDate, sendAnimationData, updateStickersOrder);
                 params.quick_reply_shortcut = parentFragment != null ? parentFragment.quickReplyShortcut : null;

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -100,6 +100,7 @@ import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -161,6 +162,7 @@ import org.telegram.messenger.UserConfig;
 import org.telegram.messenger.UserObject;
 import org.telegram.messenger.Utilities;
 import org.telegram.messenger.browser.Browser;
+import org.telegram.messenger.PgpHelper;
 import org.telegram.tgnet.ConnectionsManager;
 import org.telegram.tgnet.SerializedData;
 import org.telegram.tgnet.TLObject;
@@ -295,6 +297,8 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
@@ -552,8 +556,15 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
     private final static int copy_link_profile = 42;
     private final static int set_username = 43;
     private final static int bot_privacy = 44;
+    private final static int pgp_keys = 45;
+
+    private final static int REQUEST_PUBLIC_KEY = 700;
+    private final static int REQUEST_PRIVATE_KEY = 701;
 
     private Rect rect = new Rect();
+
+    private EditText pgpPublicField;
+    private EditText pgpPrivateField;
 
     private TextCell setAvatarCell;
 
@@ -2530,6 +2541,8 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                     });
                     builder.setNegativeButton(LocaleController.getString(R.string.Cancel), null);
                     showDialog(builder.create());
+                } else if (id == pgp_keys) {
+                    showPgpDialog();
                 } else if (id == bot_privacy) {
                     BotWebViewAttachedSheet.openPrivacy(currentAccount, userId);
                 } else if (id == gallery_menu_save) {
@@ -10358,7 +10371,8 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                         otherItem.addSubItem(gift_premium, R.drawable.msg_gift_premium, LocaleController.getString(R.string.ProfileSendAGift));
                     }
                     otherItem.addSubItem(start_secret_chat, R.drawable.msg_secret, LocaleController.getString(R.string.StartEncryptedChat));
-                    otherItem.setSubItemShown(start_secret_chat, DialogObject.isEmpty(getMessagesController().isUserContactBlocked(userId)));
+                    otherItem.addSubItem(pgp_keys, R.drawable.msg_mini_lock2, LocaleController.getString(R.string.PgpSettings));
+                    otherItem.setSubItemShown(start_secret_chat, DialogObject.isEmpty(getMessagesController().isUserContactBlocked(userId))); 
                 }
                 if (!isBot && getContactsController().contactsDict.get(userId) != null) {
                     otherItem.addSubItem(add_shortcut, R.drawable.msg_home, LocaleController.getString(R.string.AddShortcut));
@@ -11039,10 +11053,82 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
         }
     }
 
+    private void showPgpDialog() {
+        if (getParentActivity() == null) {
+            return;
+        }
+        AlertDialog.Builder builder = new AlertDialog.Builder(getParentActivity(), resourcesProvider);
+        builder.setTitle(LocaleController.getString("PgpSettings", R.string.PgpSettings));
+        LinearLayout layout = new LinearLayout(getParentActivity());
+        layout.setOrientation(LinearLayout.VERTICAL);
+        pgpPublicField = new EditText(getParentActivity());
+        pgpPublicField.setHint(LocaleController.getString("PgpPublicKey", R.string.PgpPublicKey));
+        pgpPublicField.setText(PgpHelper.getPublicKey(getDialogId()));
+        pgpPrivateField = new EditText(getParentActivity());
+        pgpPrivateField.setHint(LocaleController.getString("PgpPrivateKey", R.string.PgpPrivateKey));
+        pgpPrivateField.setText(PgpHelper.getPrivateKey());
+        Button importPub = new Button(getParentActivity());
+        importPub.setText(LocaleController.getString("Import", R.string.Import));
+        importPub.setOnClickListener(v -> {
+            try {
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("*/*");
+                startActivityForResult(intent, REQUEST_PUBLIC_KEY);
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        });
+        Button importPriv = new Button(getParentActivity());
+        importPriv.setText(LocaleController.getString("Import", R.string.Import));
+        importPriv.setOnClickListener(v -> {
+            try {
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("*/*");
+                startActivityForResult(intent, REQUEST_PRIVATE_KEY);
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        });
+        layout.addView(pgpPublicField, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 16f, 8f, 16f, 8f));
+        layout.addView(importPub, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 16f, 0f, 16f, 8f));
+        layout.addView(pgpPrivateField, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 16f, 8f, 16f, 8f));
+        layout.addView(importPriv, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 16f, 0f, 16f, 8f));
+        builder.setView(layout);
+        builder.setPositiveButton(LocaleController.getString("Save", R.string.Save), (dialog, which) -> {
+            PgpHelper.saveKeys(getDialogId(), pgpPublicField.getText().toString(), pgpPrivateField.getText().toString());
+        });
+        builder.setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null);
+        showDialog(builder.create());
+    }
+
     @Override
     public void onActivityResultFragment(int requestCode, int resultCode, Intent data) {
         if (imageUpdater != null) {
             imageUpdater.onActivityResult(requestCode, resultCode, data);
+        }
+        if (resultCode == Activity.RESULT_OK && data != null) {
+            if ((requestCode == REQUEST_PUBLIC_KEY && pgpPublicField != null) || (requestCode == REQUEST_PRIVATE_KEY && pgpPrivateField != null)) {
+                try {
+                    InputStream is = getParentActivity().getContentResolver().openInputStream(data.getData());
+                    if (is != null) {
+                        ByteArrayOutputStream out = new ByteArrayOutputStream();
+                        byte[] buf = new byte[1024];
+                        int n;
+                        while ((n = is.read(buf)) > 0) {
+                            out.write(buf, 0, n);
+                        }
+                        String text = out.toString("UTF-8");
+                        if (requestCode == REQUEST_PUBLIC_KEY) {
+                            pgpPublicField.setText(text);
+                        } else {
+                            pgpPrivateField.setText(text);
+                        }
+                        is.close();
+                    }
+                } catch (Exception e) {
+                    FileLog.e(e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add missing imports in `ProfileActivity`
- keep PGP encryption using per-chat keys with secure random
- move PGP key management to profile menu with import from files
- decrypt messages automatically before display

## Testing
- `./gradlew -p TMessagesProj compileDebugJavaWithJavac --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409d4b23e083258d646c1c2d555e15